### PR TITLE
chore: adding example with showing in pure es5 how to bundle otel 

### DIFF
--- a/opentelemetry-examples/otel-browser-es5/.gitignore
+++ b/opentelemetry-examples/otel-browser-es5/.gitignore
@@ -1,0 +1,3 @@
+package-lock.json
+*.iml
+otel.min.js

--- a/opentelemetry-examples/otel-browser-es5/README.md
+++ b/opentelemetry-examples/otel-browser-es5/README.md
@@ -1,0 +1,21 @@
+### Installation
+1. First install required packages
+```bash
+npm install
+```
+It will also automatically build and create a file `otel.min.js`
+2. In folder `www` You will have index.html and `otel.min.js` which contains all necessary packages from OpenTelemetry
+If for any reason you want to add more plugins / modify this file just edit file `www/index.js` and either remove or add new plugins to be included automatically in the bundled file.
+3. If you make any changes or want to simply regenrate file `otel.min.js` just run
+```bash
+npm run build
+```
+
+### Development
+For your convenience there is a script that will automatically build changes on the fly and open the page for testing. Just run
+```bash
+npm start
+```
+
+### Angular
+If you are using angular and already have a `zone.js` instead of using `@opentelemetry/context-zone` use `@opentelemetry/context-zone-peer-dep`  

--- a/opentelemetry-examples/otel-browser-es5/package.json
+++ b/opentelemetry-examples/otel-browser-es5/package.json
@@ -1,0 +1,33 @@
+{
+  "name": "web-example",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "build": "webpack --config webpack.production.js",
+    "postinstall": "npm run build",
+    "start": "webpack serve --open --progress --port 8090 --config webpack.dev.js --hot --inline --host 0.0.0.0 --content-base www"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.12.16",
+    "@babel/plugin-transform-runtime": "^7.12.15",
+    "@babel/preset-env": "^7.12.16",
+    "babel-loader": "^8.2.2",
+    "terser-webpack-plugin": "^5.1.1",
+    "ts-loader": "^8.0.17",
+    "webpack": "^5.21.2",
+    "webpack-cli": "^4.5.0",
+    "webpack-dev-server": "^3.11.2",
+    "webpack-merge": "^5.7.3"
+  },
+  "dependencies": {
+    "@opentelemetry/context-zone": "^0.15.0",
+    "@opentelemetry/exporter-collector": "^0.15.0",
+    "@opentelemetry/instrumentation": "^0.15.0",
+    "@opentelemetry/instrumentation-xml-http-request": "^0.15.0",
+    "@opentelemetry/plugin-document-load": "^0.13.1",
+    "@opentelemetry/instrumentation-user-interaction": "^0.13.1",
+    "@opentelemetry/tracing": "^0.15.0",
+    "@opentelemetry/web": "^0.15.0"
+  }
+}

--- a/opentelemetry-examples/otel-browser-es5/webpack.common.js
+++ b/opentelemetry-examples/otel-browser-es5/webpack.common.js
@@ -1,0 +1,42 @@
+const path = require('path');
+const directory = path.resolve(__dirname);
+
+module.exports = {
+  entry: {
+    'otel': 'www/index.js',
+  },
+  output: {
+    path: path.resolve(__dirname, 'www'),
+    filename: 'otel.min.js',
+  },
+  target: ['web', 'es5'],
+  module: {
+    rules: [
+      {
+        test: /\.js[x]?$/,
+        exclude: /(node_modules)/,
+        use: {
+          loader: 'babel-loader',
+          options: {
+            presets: ['@babel/preset-env'],
+            plugins: ['@babel/plugin-transform-runtime']
+          },
+        },
+      },
+      {
+        test: /\.ts$/,
+        exclude: /(node_modules)/,
+        use: {
+          loader: 'ts-loader',
+        },
+      },
+    ],
+  },
+  resolve: {
+    modules: [
+      path.resolve(directory),
+      'node_modules',
+    ],
+    extensions: ['.ts', '.js', '.jsx', '.json'],
+  },
+};

--- a/opentelemetry-examples/otel-browser-es5/webpack.dev.js
+++ b/opentelemetry-examples/otel-browser-es5/webpack.dev.js
@@ -1,0 +1,11 @@
+const { merge } = require('webpack-merge');
+const common = require('./webpack.common.js');
+const path = require('path');
+
+module.exports = merge(common, {
+  mode: 'development',
+  devtool: 'inline-source-map',
+  devServer: {
+    contentBase: path.resolve(__dirname),
+  },
+});

--- a/opentelemetry-examples/otel-browser-es5/webpack.production.js
+++ b/opentelemetry-examples/otel-browser-es5/webpack.production.js
@@ -1,0 +1,17 @@
+const { merge } = require('webpack-merge');
+const common = require('./webpack.common.js');
+const TerserPlugin = require('terser-webpack-plugin');
+
+module.exports = merge(common, {
+  mode: 'production',
+  optimization: {
+    minimize: true,
+    minimizer: [new TerserPlugin({
+      extractComments: false,
+      terserOptions: {
+        ie8: true,
+        safari10: true,
+      },
+    })],
+  },
+});

--- a/opentelemetry-examples/otel-browser-es5/www/index.html
+++ b/opentelemetry-examples/otel-browser-es5/www/index.html
@@ -1,0 +1,65 @@
+<!DOCTYPE html>
+<html lang="en">
+
+<head>
+    <meta charset="utf-8">
+    <title>Demo</title>
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <!-- otel.min.js is exposing everything globally -->
+    <script type="text/javascript" src="otel.min.js"></script>
+    <script type="text/javascript">
+      var tracerProvider = new WebTracerProvider();
+      tracerProvider.addSpanProcessor(new SimpleSpanProcessor(new ConsoleSpanExporter()));
+      tracerProvider.addSpanProcessor(new BatchSpanProcessor(new CollectorTraceExporter({
+        headers: {
+          'Lightstep-Access-Token': '',
+        },
+        serviceName: 'web-example',
+        url: 'https://ingest.lightstep.com:443/api/v2/otel/trace',
+      })));
+
+      tracerProvider.register({
+        contextManager: new ZoneContextManager(),
+      });
+
+      registerInstrumentations({
+        instrumentations: [
+          new DocumentLoad(),
+          new UserInteractionInstrumentation(),
+          new XMLHttpRequestInstrumentation(),
+        ],
+        tracerProvider: tracerProvider,
+      });
+    </script>
+</head>
+
+<body>
+Open console to see traces<br/>
+Also update "Lightstep-Access-Token" to see traces in Lightstep<br/>
+<button id="button">Click me</button>
+
+<script>
+  function getData(url, callback) {
+    var req = new XMLHttpRequest();
+    req.open('GET', url, true);
+    req.setRequestHeader('Content-Type', 'application/json');
+    req.setRequestHeader('Accept', 'application/json');
+    req.send();
+    req.onload = function () {
+      callback();
+    };
+  }
+
+  function clickMe() {
+    // just an example to download something
+    getData('https://httpbin.org/get?a=1', () => {
+      console.log('data downloaded 1');
+    });
+  }
+
+  document.getElementById('button').addEventListener('click', clickMe);
+</script>
+
+</body>
+
+</html>

--- a/opentelemetry-examples/otel-browser-es5/www/index.js
+++ b/opentelemetry-examples/otel-browser-es5/www/index.js
@@ -1,0 +1,26 @@
+import { BatchSpanProcessor, ConsoleSpanExporter, SimpleSpanProcessor } from '@opentelemetry/tracing';
+import { WebTracerProvider } from '@opentelemetry/web';
+import { ZoneContextManager } from '@opentelemetry/context-zone';
+import { CollectorTraceExporter } from '@opentelemetry/exporter-collector';
+import { registerInstrumentations } from '@opentelemetry/instrumentation';
+import { XMLHttpRequestInstrumentation } from '@opentelemetry/instrumentation-xml-http-request';
+import { UserInteractionInstrumentation } from '@opentelemetry/instrumentation-user-interaction';
+import { DocumentLoad } from '@opentelemetry/plugin-document-load';
+
+const OTEL = {
+  ConsoleSpanExporter,
+  SimpleSpanProcessor,
+  BatchSpanProcessor,
+  WebTracerProvider,
+  ZoneContextManager,
+  registerInstrumentations,
+  CollectorTraceExporter,
+  XMLHttpRequestInstrumentation,
+  UserInteractionInstrumentation,
+  DocumentLoad,
+};
+
+// make all available globally on window
+Object.keys(OTEL).forEach(key => {
+  window[key] = OTEL[key];
+});


### PR DESCRIPTION
and use it without any es6 imports etc.